### PR TITLE
Style changes

### DIFF
--- a/app/assets/scripts/map.js
+++ b/app/assets/scripts/map.js
@@ -344,6 +344,8 @@ function populateListDiv() {
   // Can only add handlers to elements in template after compilation
   $(".list-resource").each(function(i, element) {
     element.addEventListener('click', function() {
+      $('.list-resource').removeClass('list-selected');
+      $(this).addClass('list-selected');
       markerListener(markersToShow[i], 'click');
     });
   });

--- a/app/assets/styles/map.scss
+++ b/app/assets/styles/map.scss
@@ -145,6 +145,11 @@ $font-size: 14px;
     display: inline-block;
   }
 
+  &.list-selected {
+    .ui.header a, #resource-list-chevron a {
+      color: #000;
+    }
+  }
 }
 
 #category, #avg_rating {

--- a/app/assets/styles/map.scss
+++ b/app/assets/styles/map.scss
@@ -2,7 +2,8 @@ $accent-color: #2C9FA3;
 $accent-color-light: #2DBDC2;
 $accent-color-grey: #EEEEEE;
 $accent-color-dark-grey: #555;
-$secondary-color: #EDA21C;
+$secondary-color: #FF937C;
+$secondary-color-light: #FFA491;
 $font-choice: 'Nunito Sans', sans-serif;
 $font-size: 14px;
 
@@ -139,15 +140,19 @@ $font-size: 14px;
     padding-right: 10px;
 
     .ui.small.label {
-      font-size: $font-size;
+      font-size: 12px;
     }
   }
 
   .ui.label {
-    background-color: #DDDDDD;
+    background-color: inherit;
+    border: 1px solid $accent-color-light;
+    color: $accent-color-light;
     display: inline-block;
+    font-weight: normal;
     margin-left: 0;
     margin-top: 0.5em;
+    padding-top: 0.4em;
   }
 
   #resource-list-chevron {
@@ -164,7 +169,7 @@ $font-size: 14px;
 
   &:hover {
     .ui.header a, #resource-list-chevron a {
-      color: $accent-color-dark-grey;
+      color: $accent-color-light;
     }
   }
 
@@ -198,7 +203,7 @@ $font-size: 14px;
   }
 
   #more-info-label {
-    background-color: $accent-color;
+    background-color: $secondary-color;
     color: white;
     cursor: pointer;
     font-weight: 300;
@@ -208,12 +213,15 @@ $font-size: 14px;
   }
 
   #more-info-label:hover {
-    background-color: $accent-color-light;
+    background-color: $secondary-color-light;
   }
 }
 
 #avg_rating-marker {
-  color: $accent-color;
+  background-color: inherit;
+  border: 1px solid $secondary-color-light;
+  color: $secondary-color-light;
+  font-size: 11px;
   margin-right: 0px;
   position: relative;
   right: 8px;
@@ -279,9 +287,14 @@ $font-size: 14px;
   }
 
   .ui.label {
+    background-color: inherit;
+    border: 1px solid $accent-color-light;
+    color: $accent-color-light;
     font-size: $font-size;
+    font-weight: normal;
     margin-top: 0.4em;
     margin-bottom: 1em;
+    padding-top: 0.4em;
   }
 
   .ui.header  {

--- a/app/assets/styles/map.scss
+++ b/app/assets/styles/map.scss
@@ -1,6 +1,8 @@
 $accent-color: #2C9FA3;
 $accent-color-light: #2DBDC2;
 $accent-color-grey: #EEEEEE;
+$accent-color-dark-grey: #555;
+$secondary-color: #EDA21C;
 $font-choice: 'Nunito Sans', sans-serif;
 $font-size: 14px;
 
@@ -11,7 +13,7 @@ $font-size: 14px;
   width: 100%;
 
   #left-column {
-    background-color: #EEEEEE;
+    background-color: $accent-color-grey;
     border: 1px solid #CCCCCC;
     height: 100%;
     overflow-y: scroll;
@@ -99,7 +101,7 @@ $font-size: 14px;
 }
 
 #search-divider, #results-divider {
-  color: #555;
+  color: $accent-color-dark-grey;
 }
 
 #results-divider {
@@ -154,9 +156,15 @@ $font-size: 14px;
     display: block;
   }
 
+  &:hover {
+    .ui.header a, #resource-list-chevron a {
+      color: $accent-color-dark-grey;
+    }
+  }
+
   &.list-selected {
     .ui.header a, #resource-list-chevron a {
-      color: #000;
+      color: $secondary-color;
     }
   }
 }
@@ -206,13 +214,31 @@ $font-size: 14px;
 }
 
 #map-footer {
-  background-color: #EEEEEE;
+  background-color: $accent-color-grey;
   display: none;
   overflow-y: auto;
   padding: 0.5em;
 
-  #mobile-list-btn p {
-    display: inline-block;
+  .marker-info .ui.header {
+    margin-bottom: 0.5em;
+  }
+
+  #mobile-list-btn {
+    background-color: $accent-color-grey;
+    border: none;
+    color: $accent-color-dark-grey;
+    cursor: pointer;
+    font-weight: normal;
+    margin-left: 0;
+    padding-left: 0;
+
+    p {
+      display: inline-block;
+    }
+
+    &:hover {
+      color: #000;
+    }
   }
 }
 

--- a/app/static/styles/app.css
+++ b/app/static/styles/app.css
@@ -146,13 +146,13 @@ h1.ui.header, h2.ui.header {
 }
 
 /******** GENERAL MAP/LIST GRID STYLES *************/
-@media -sass-debug-info{filename{}line{font-family:\0000310}}
+@media -sass-debug-info{filename{}line{font-family:\0000311}}
 #map-list-grid {
   padding: 1em;
   position: absolute;
   width: 100%;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000315}}
+@media -sass-debug-info{filename{}line{font-family:\0000316}}
 #map-list-grid #left-column {
   background-color: #EEEEEE;
   border: 1px solid #CCCCCC;
@@ -160,27 +160,27 @@ h1.ui.header, h2.ui.header {
   overflow-y: scroll;
   padding: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000323}}
+@media -sass-debug-info{filename{}line{font-family:\0000324}}
 #map-list-grid #right-column {
   padding: 0;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000327}}
+@media -sass-debug-info{filename{}line{font-family:\0000328}}
 #map-list-grid.grid-space-large {
   padding-left: 2em;
   padding-right: 2em;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000332}}
+@media -sass-debug-info{filename{}line{font-family:\0000333}}
 #map-list-grid.grid-space-small {
   padding: 0;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000337}}
+@media -sass-debug-info{filename{}line{font-family:\0000338}}
 #left-column-divider {
   margin-bottom: 0;
 }
 
 /*************** SEARCH STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\0000343}}
+@media -sass-debug-info{filename{}line{font-family:\0000344}}
 #pac-input, #resources-input {
   background-color: #fff;
   float: left;
@@ -190,50 +190,50 @@ h1.ui.header, h2.ui.header {
   text-overflow: ellipsis;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000352}}
+@media -sass-debug-info{filename{}line{font-family:\0000353}}
 #pac-input:focus, #resources-input:focus, #search-resources-req-options:focus {
   border-color: #2C9FA3;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000356}}
+@media -sass-debug-info{filename{}line{font-family:\0000357}}
 #location-search, #search-keyword, #resources-input {
   height: 40px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000361}}
+@media -sass-debug-info{filename{}line{font-family:\0000362}}
 #resource-search {
   background-color: #F8F8F8;
   box-shadow: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000367}}
+@media -sass-debug-info{filename{}line{font-family:\0000368}}
 .req-desc-name {
   font-weight: bold;
   text-transform: capitalize;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000372}}
+@media -sass-debug-info{filename{}line{font-family:\0000373}}
 .descriptor-group {
   margin: 3px;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000375}}
+@media -sass-debug-info{filename{}line{font-family:\0000376}}
 .descriptor-group h5 {
   font-family: "Nunito Sans", sans-serif;
   margin: 0 0 5px 0;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000381}}
+@media -sass-debug-info{filename{}line{font-family:\0000382}}
 .option-group, .option-group-advanced {
   margin-bottom: 10px;
   margin-top: 10px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000386}}
+@media -sass-debug-info{filename{}line{font-family:\0000387}}
 .option-group-advanced {
   display: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000390}}
+@media -sass-debug-info{filename{}line{font-family:\0000391}}
 #advanced-filters-showhide {
   color: #2C9FA3;
   cursor: pointer;
@@ -241,51 +241,51 @@ h1.ui.header, h2.ui.header {
   text-decoration: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000397}}
+@media -sass-debug-info{filename{}line{font-family:\0000398}}
 #advanced-filters-showhide:hover {
   color: #2DBDC2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003101}}
+@media -sass-debug-info{filename{}line{font-family:\00003102}}
 .checkbox-option {
   margin-right: 5px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003105}}
+@media -sass-debug-info{filename{}line{font-family:\00003106}}
 .descriptor {
   display: block;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003109}}
+@media -sass-debug-info{filename{}line{font-family:\00003110}}
 #search-divider, #results-divider {
   color: #555;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003113}}
+@media -sass-debug-info{filename{}line{font-family:\00003114}}
 #results-divider {
   margin-bottom: 0px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003117}}
+@media -sass-debug-info{filename{}line{font-family:\00003118}}
 #search-keyword {
   margin: 0 0 5px 0;
 }
 
 /*************** LIST STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003122}}
+@media -sass-debug-info{filename{}line{font-family:\00003123}}
 #list {
   margin-bottom: 0px;
   margin-top: 0px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003128}}
+@media -sass-debug-info{filename{}line{font-family:\00003129}}
 #list > .item.list-resource {
   cursor: pointer;
   margin: 0.5em;
   padding-bottom: 0.5em;
   padding-top: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003134}}
+@media -sass-debug-info{filename{}line{font-family:\00003135}}
 #list > .item.list-resource .sub.header {
   float: left;
   font-family: "Nunito Sans", sans-serif;
@@ -293,18 +293,22 @@ h1.ui.header, h2.ui.header {
   margin-right: 15px;
   padding-right: 10px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003141}}
+@media -sass-debug-info{filename{}line{font-family:\00003142}}
 #list > .item.list-resource .sub.header .ui.small.label {
-  font-size: 14px;
+  font-size: 12px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003146}}
+@media -sass-debug-info{filename{}line{font-family:\00003147}}
 #list > .item.list-resource .ui.label {
-  background-color: #DDDDDD;
+  background-color: inherit;
+  border: 1px solid #2DBDC2;
+  color: #2DBDC2;
   display: inline-block;
+  font-weight: normal;
   margin-left: 0;
   margin-top: 0.5em;
+  padding-top: 0.4em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003153}}
+@media -sass-debug-info{filename{}line{font-family:\00003158}}
 #list > .item.list-resource #resource-list-chevron {
   float: right;
   margin-top: 1.5em;
@@ -312,20 +316,20 @@ h1.ui.header, h2.ui.header {
   right: 1em;
   vertical-align: middle;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003161}}
+@media -sass-debug-info{filename{}line{font-family:\00003166}}
 #list > .item.list-resource .header {
   display: block;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003166}}
+@media -sass-debug-info{filename{}line{font-family:\00003171}}
 #list > .item.list-resource:hover .ui.header a, #list > .item.list-resource:hover #resource-list-chevron a {
-  color: #555;
+  color: #2DBDC2;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003172}}
+@media -sass-debug-info{filename{}line{font-family:\00003177}}
 #list > .item.list-resource.list-selected .ui.header a, #list > .item.list-resource.list-selected #resource-list-chevron a {
-  color: #EDA21C;
+  color: #FF937C;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003178}}
+@media -sass-debug-info{filename{}line{font-family:\00003183}}
 #category, #avg_rating {
   height: 2em;
   display: inline-block;
@@ -333,7 +337,7 @@ h1.ui.header, h2.ui.header {
 }
 
 /*************** MAP STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003185}}
+@media -sass-debug-info{filename{}line{font-family:\00003190}}
 #map {
   border: solid #CCCCCC;
   border-width: 1px 1px 1px 0;
@@ -341,17 +345,17 @@ h1.ui.header, h2.ui.header {
   width: 100%;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003193}}
+@media -sass-debug-info{filename{}line{font-family:\00003198}}
 .marker-info {
   padding: 0.25em 0.25em 0em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003196}}
+@media -sass-debug-info{filename{}line{font-family:\00003201}}
 .marker-info #address-marker {
   margin-bottom: 2px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003200}}
+@media -sass-debug-info{filename{}line{font-family:\00003205}}
 .marker-info #more-info-label {
-  background-color: #2C9FA3;
+  background-color: #FF937C;
   color: white;
   cursor: pointer;
   font-weight: 300;
@@ -359,31 +363,34 @@ h1.ui.header, h2.ui.header {
   right: 8px;
   text-decoration: none;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003210}}
+@media -sass-debug-info{filename{}line{font-family:\00003215}}
 .marker-info #more-info-label:hover {
-  background-color: #2DBDC2;
+  background-color: #FFA491;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003215}}
+@media -sass-debug-info{filename{}line{font-family:\00003220}}
 #avg_rating-marker {
-  color: #2C9FA3;
+  background-color: inherit;
+  border: 1px solid #FFA491;
+  color: #FFA491;
+  font-size: 11px;
   margin-right: 0px;
   position: relative;
   right: 8px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003222}}
+@media -sass-debug-info{filename{}line{font-family:\00003230}}
 #map-footer {
   background-color: #EEEEEE;
   display: none;
   overflow-y: auto;
   padding: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003228}}
+@media -sass-debug-info{filename{}line{font-family:\00003236}}
 #map-footer .marker-info .ui.header {
   margin-bottom: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003232}}
+@media -sass-debug-info{filename{}line{font-family:\00003240}}
 #map-footer #mobile-list-btn {
   background-color: #EEEEEE;
   border: none;
@@ -393,17 +400,17 @@ h1.ui.header, h2.ui.header {
   margin-left: 0;
   padding-left: 0;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003241}}
+@media -sass-debug-info{filename{}line{font-family:\00003249}}
 #map-footer #mobile-list-btn p {
   display: inline-block;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003245}}
+@media -sass-debug-info{filename{}line{font-family:\00003253}}
 #map-footer #mobile-list-btn:hover {
   color: #000;
 }
 
 /*************** RESOURCE VIEW SPECIFIC STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003253}}
+@media -sass-debug-info{filename{}line{font-family:\00003261}}
 #resource-info {
   background-color: #F8F8F8;
   border: solid #CCCCCC;
@@ -412,42 +419,47 @@ h1.ui.header, h2.ui.header {
   overflow: scroll;
   padding: 1.25em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003262}}
+@media -sass-debug-info{filename{}line{font-family:\00003270}}
 #resource-info > .ui.header > .sub.header > .ui.label {
   margin-left: 0px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003266}}
+@media -sass-debug-info{filename{}line{font-family:\00003274}}
 #resource-info #resource-name {
   display: inline;
   font-size: 36px;
   padding-bottom: 1em;
   padding-top: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003273}}
+@media -sass-debug-info{filename{}line{font-family:\00003281}}
 #resource-info .successMessage {
   display: none;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003277}}
+@media -sass-debug-info{filename{}line{font-family:\00003285}}
 #resource-info .sub.header {
   font-size: 14px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003281}}
+@media -sass-debug-info{filename{}line{font-family:\00003289}}
 #resource-info .ui.label {
+  background-color: inherit;
+  border: 1px solid #2DBDC2;
+  color: #2DBDC2;
   font-size: 14px;
+  font-weight: normal;
   margin-top: 0.4em;
   margin-bottom: 1em;
+  padding-top: 0.4em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003287}}
+@media -sass-debug-info{filename{}line{font-family:\00003300}}
 #resource-info .ui.header {
   color: #2C9FA3;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003292}}
+@media -sass-debug-info{filename{}line{font-family:\00003305}}
 #descriptor-name {
   font-family: "Nunito Sans", sans-serif;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003296}}
+@media -sass-debug-info{filename{}line{font-family:\00003309}}
 #back-button {
   color: #2C9FA3;
   display: inline-block;
@@ -456,41 +468,41 @@ h1.ui.header, h2.ui.header {
   z-index: 2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003304}}
+@media -sass-debug-info{filename{}line{font-family:\00003317}}
 #back-button:hover {
   color: #2DBDC2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003308}}
+@media -sass-debug-info{filename{}line{font-family:\00003321}}
 #single-resource-map {
   height: 400px;
   width: 100%;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003313}}
+@media -sass-debug-info{filename{}line{font-family:\00003326}}
 #user-rating, .successMessage {
   margin-bottom: 1em;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003317}}
+@media -sass-debug-info{filename{}line{font-family:\00003330}}
 #user-rating {
   background-color: #F8F8F8;
   box-shadow: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003322}}
+@media -sass-debug-info{filename{}line{font-family:\00003335}}
 #avg_rating {
   color: #2C9FA3;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003326}}
+@media -sass-debug-info{filename{}line{font-family:\00003339}}
 #submit-rating {
   background-color: #2C9FA3;
   color: #fff;
   font-weight: 400;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003332}}
+@media -sass-debug-info{filename{}line{font-family:\00003345}}
 #submit-rating:hover {
   background-color: #2DBDC2;
 }

--- a/app/static/styles/app.css
+++ b/app/static/styles/app.css
@@ -146,13 +146,13 @@ h1.ui.header, h2.ui.header {
 }
 
 /******** GENERAL MAP/LIST GRID STYLES *************/
-@media -sass-debug-info{filename{}line{font-family:\000038}}
+@media -sass-debug-info{filename{}line{font-family:\0000310}}
 #map-list-grid {
   padding: 1em;
   position: absolute;
   width: 100%;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000313}}
+@media -sass-debug-info{filename{}line{font-family:\0000315}}
 #map-list-grid #left-column {
   background-color: #EEEEEE;
   border: 1px solid #CCCCCC;
@@ -160,27 +160,27 @@ h1.ui.header, h2.ui.header {
   overflow-y: scroll;
   padding: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000321}}
+@media -sass-debug-info{filename{}line{font-family:\0000323}}
 #map-list-grid #right-column {
   padding: 0;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000325}}
+@media -sass-debug-info{filename{}line{font-family:\0000327}}
 #map-list-grid.grid-space-large {
   padding-left: 2em;
   padding-right: 2em;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000330}}
+@media -sass-debug-info{filename{}line{font-family:\0000332}}
 #map-list-grid.grid-space-small {
   padding: 0;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000335}}
+@media -sass-debug-info{filename{}line{font-family:\0000337}}
 #left-column-divider {
   margin-bottom: 0;
 }
 
 /*************** SEARCH STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\0000341}}
+@media -sass-debug-info{filename{}line{font-family:\0000343}}
 #pac-input, #resources-input {
   background-color: #fff;
   float: left;
@@ -190,44 +190,44 @@ h1.ui.header, h2.ui.header {
   text-overflow: ellipsis;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000350}}
+@media -sass-debug-info{filename{}line{font-family:\0000352}}
 #pac-input:focus, #resources-input:focus, #search-resources-req-options:focus {
   border-color: #2C9FA3;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000354}}
+@media -sass-debug-info{filename{}line{font-family:\0000356}}
 #location-search, #search-keyword, #resources-input {
   height: 40px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000359}}
+@media -sass-debug-info{filename{}line{font-family:\0000361}}
 #resource-search {
   background-color: #F8F8F8;
   box-shadow: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000364}}
+@media -sass-debug-info{filename{}line{font-family:\0000366}}
 .descriptor-group {
   margin: 3px;
 }
-@media -sass-debug-info{filename{}line{font-family:\0000367}}
+@media -sass-debug-info{filename{}line{font-family:\0000369}}
 .descriptor-group h5 {
   font-family: "Nunito Sans", sans-serif;
   margin: 0 0 5px 0;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000373}}
+@media -sass-debug-info{filename{}line{font-family:\0000375}}
 .option-group, .option-group-advanced {
   margin-bottom: 10px;
   margin-top: 10px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000378}}
+@media -sass-debug-info{filename{}line{font-family:\0000380}}
 .option-group-advanced {
   display: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000382}}
+@media -sass-debug-info{filename{}line{font-family:\0000384}}
 #advanced-filters-showhide {
   color: #2C9FA3;
   cursor: pointer;
@@ -235,51 +235,51 @@ h1.ui.header, h2.ui.header {
   text-decoration: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000389}}
+@media -sass-debug-info{filename{}line{font-family:\0000391}}
 #advanced-filters-showhide:hover {
   color: #2DBDC2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000393}}
+@media -sass-debug-info{filename{}line{font-family:\0000395}}
 .checkbox-option {
   margin-right: 5px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\0000397}}
+@media -sass-debug-info{filename{}line{font-family:\0000399}}
 .descriptor {
   display: block;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003101}}
+@media -sass-debug-info{filename{}line{font-family:\00003103}}
 #search-divider, #results-divider {
   color: #555;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003105}}
+@media -sass-debug-info{filename{}line{font-family:\00003107}}
 #results-divider {
   margin-bottom: 0px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003109}}
+@media -sass-debug-info{filename{}line{font-family:\00003111}}
 #search-keyword {
   margin: 0 0 5px 0;
 }
 
 /*************** LIST STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003114}}
+@media -sass-debug-info{filename{}line{font-family:\00003116}}
 #list {
   margin-bottom: 0px;
   margin-top: 0px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003120}}
+@media -sass-debug-info{filename{}line{font-family:\00003122}}
 #list > .item.list-resource {
   cursor: pointer;
   margin: 0.5em;
   padding-bottom: 0.5em;
   padding-top: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003126}}
+@media -sass-debug-info{filename{}line{font-family:\00003128}}
 #list > .item.list-resource .sub.header {
   float: left;
   font-family: "Nunito Sans", sans-serif;
@@ -287,18 +287,18 @@ h1.ui.header, h2.ui.header {
   margin-right: 15px;
   padding-right: 10px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003133}}
+@media -sass-debug-info{filename{}line{font-family:\00003135}}
 #list > .item.list-resource .sub.header .ui.small.label {
   font-size: 14px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003138}}
+@media -sass-debug-info{filename{}line{font-family:\00003140}}
 #list > .item.list-resource .ui.label {
   background-color: #DDDDDD;
   display: inline-block;
   margin-left: 0;
   margin-top: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003145}}
+@media -sass-debug-info{filename{}line{font-family:\00003147}}
 #list > .item.list-resource #resource-list-chevron {
   float: right;
   margin-top: 1.5em;
@@ -306,16 +306,20 @@ h1.ui.header, h2.ui.header {
   right: 1em;
   vertical-align: middle;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003153}}
+@media -sass-debug-info{filename{}line{font-family:\00003155}}
 #list > .item.list-resource .header {
   display: block;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003158}}
+@media -sass-debug-info{filename{}line{font-family:\00003160}}
+#list > .item.list-resource:hover .ui.header a, #list > .item.list-resource:hover #resource-list-chevron a {
+  color: #555;
+}
+@media -sass-debug-info{filename{}line{font-family:\00003166}}
 #list > .item.list-resource.list-selected .ui.header a, #list > .item.list-resource.list-selected #resource-list-chevron a {
-  color: #000;
+  color: #EDA21C;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003164}}
+@media -sass-debug-info{filename{}line{font-family:\00003172}}
 #category, #avg_rating {
   height: 2em;
   display: inline-block;
@@ -323,7 +327,7 @@ h1.ui.header, h2.ui.header {
 }
 
 /*************** MAP STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003171}}
+@media -sass-debug-info{filename{}line{font-family:\00003179}}
 #map {
   border: solid #CCCCCC;
   border-width: 1px 1px 1px 0;
@@ -331,15 +335,15 @@ h1.ui.header, h2.ui.header {
   width: 100%;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003179}}
+@media -sass-debug-info{filename{}line{font-family:\00003187}}
 .marker-info {
   padding: 0.25em 0.25em 0em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003182}}
+@media -sass-debug-info{filename{}line{font-family:\00003190}}
 .marker-info #address-marker {
   margin-bottom: 2px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003186}}
+@media -sass-debug-info{filename{}line{font-family:\00003194}}
 .marker-info #more-info-label {
   background-color: #2C9FA3;
   color: white;
@@ -349,12 +353,12 @@ h1.ui.header, h2.ui.header {
   right: 8px;
   text-decoration: none;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003196}}
+@media -sass-debug-info{filename{}line{font-family:\00003204}}
 .marker-info #more-info-label:hover {
   background-color: #2DBDC2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003201}}
+@media -sass-debug-info{filename{}line{font-family:\00003209}}
 #avg_rating-marker {
   color: #2C9FA3;
   margin-right: 0px;
@@ -362,20 +366,38 @@ h1.ui.header, h2.ui.header {
   right: 8px;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003208}}
+@media -sass-debug-info{filename{}line{font-family:\00003216}}
 #map-footer {
   background-color: #EEEEEE;
   display: none;
   overflow-y: auto;
   padding: 0.5em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003214}}
+@media -sass-debug-info{filename{}line{font-family:\00003222}}
+#map-footer .marker-info .ui.header {
+  margin-bottom: 0.5em;
+}
+@media -sass-debug-info{filename{}line{font-family:\00003226}}
+#map-footer #mobile-list-btn {
+  background-color: #EEEEEE;
+  border: none;
+  color: #555;
+  cursor: pointer;
+  font-weight: normal;
+  margin-left: 0;
+  padding-left: 0;
+}
+@media -sass-debug-info{filename{}line{font-family:\00003235}}
 #map-footer #mobile-list-btn p {
   display: inline-block;
 }
+@media -sass-debug-info{filename{}line{font-family:\00003239}}
+#map-footer #mobile-list-btn:hover {
+  color: #000;
+}
 
 /*************** RESOURCE VIEW SPECIFIC STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003221}}
+@media -sass-debug-info{filename{}line{font-family:\00003247}}
 #resource-info {
   background-color: #F8F8F8;
   border: solid #CCCCCC;
@@ -384,42 +406,42 @@ h1.ui.header, h2.ui.header {
   overflow: scroll;
   padding: 1.25em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003230}}
+@media -sass-debug-info{filename{}line{font-family:\00003256}}
 #resource-info > .ui.header > .sub.header > .ui.label {
   margin-left: 0px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003234}}
+@media -sass-debug-info{filename{}line{font-family:\00003260}}
 #resource-info #resource-name {
   display: inline;
   font-size: 36px;
   padding-bottom: 1em;
   padding-top: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003241}}
+@media -sass-debug-info{filename{}line{font-family:\00003267}}
 #resource-info .successMessage {
   display: none;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003245}}
+@media -sass-debug-info{filename{}line{font-family:\00003271}}
 #resource-info .sub.header {
   font-size: 14px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003249}}
+@media -sass-debug-info{filename{}line{font-family:\00003275}}
 #resource-info .ui.label {
   font-size: 14px;
   margin-top: 0.4em;
   margin-bottom: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003255}}
+@media -sass-debug-info{filename{}line{font-family:\00003281}}
 #resource-info .ui.header {
   color: #2C9FA3;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003261}}
+@media -sass-debug-info{filename{}line{font-family:\00003287}}
 #descriptor-name {
   font-family: "Nunito Sans", sans-serif;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003265}}
+@media -sass-debug-info{filename{}line{font-family:\00003291}}
 #back-button {
   color: #2C9FA3;
   display: inline-block;
@@ -428,41 +450,41 @@ h1.ui.header, h2.ui.header {
   z-index: 2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003273}}
+@media -sass-debug-info{filename{}line{font-family:\00003299}}
 #back-button:hover {
   color: #2DBDC2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003277}}
+@media -sass-debug-info{filename{}line{font-family:\00003303}}
 #single-resource-map {
   height: 400px;
   width: 100%;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003282}}
+@media -sass-debug-info{filename{}line{font-family:\00003308}}
 #user-rating, .successMessage {
   margin-bottom: 1em;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003286}}
+@media -sass-debug-info{filename{}line{font-family:\00003312}}
 #user-rating {
   background-color: #F8F8F8;
   box-shadow: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003291}}
+@media -sass-debug-info{filename{}line{font-family:\00003317}}
 #avg_rating {
   color: #2C9FA3;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003295}}
+@media -sass-debug-info{filename{}line{font-family:\00003321}}
 #submit-rating {
   background-color: #2C9FA3;
   color: #fff;
   font-weight: 400;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003301}}
+@media -sass-debug-info{filename{}line{font-family:\00003327}}
 #submit-rating:hover {
   background-color: #2DBDC2;
 }

--- a/app/static/styles/app.css
+++ b/app/static/styles/app.css
@@ -20,10 +20,10 @@
   left: 50%;
   margin-bottom: 50px;
   position: absolute;
-  -webkit-transform: translate(-50%, 0%);
-  -ms-transform: translate(-50%, 0%);
-  transform: translate(-50%, 0%);
   top: 75px;
+  transform: translate(-50%, 0%);
+  -ms-transform: translate(-50%, 0%);
+  -webkit-transform: translate(-50%, 0%);
 }
 
 @media -sass-debug-info{filename{}line{font-family:\0000312}}
@@ -173,7 +173,7 @@ h1.ui.header, h2.ui.header {
 }
 
 @media -sass-debug-info{filename{}line{font-family:\0000341}}
-input {
+#pac-input:focus, #resources-input:focus, #search-resources-req-options:focus {
   border-color: #2C9FA3;
 }
 
@@ -292,8 +292,12 @@ input {
 #list > .item.list-resource .header {
   display: inline-block;
 }
+@media -sass-debug-info{filename{}line{font-family:\00003149}}
+#list > .item.list-resource.list-selected .ui.header a, #list > .item.list-resource.list-selected #resource-list-chevron a {
+  color: #000;
+}
 
-@media -sass-debug-info{filename{}line{font-family:\00003150}}
+@media -sass-debug-info{filename{}line{font-family:\00003155}}
 #category, #avg_rating {
   height: 2em;
   display: inline-block;
@@ -301,7 +305,7 @@ input {
 }
 
 /*************** MAP STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003157}}
+@media -sass-debug-info{filename{}line{font-family:\00003162}}
 #map {
   border: solid #CCCCCC;
   border-width: 1px 1px 1px 0;
@@ -309,15 +313,15 @@ input {
   width: 100%;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003165}}
+@media -sass-debug-info{filename{}line{font-family:\00003170}}
 .marker-info {
   padding: 0.25em 0.25em 0em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003168}}
+@media -sass-debug-info{filename{}line{font-family:\00003173}}
 .marker-info #address-marker {
   margin-bottom: 2px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003172}}
+@media -sass-debug-info{filename{}line{font-family:\00003177}}
 .marker-info #more-info-label {
   background-color: #2C9FA3;
   color: white;
@@ -327,12 +331,12 @@ input {
   right: 8px;
   text-decoration: none;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003182}}
+@media -sass-debug-info{filename{}line{font-family:\00003187}}
 .marker-info #more-info-label:hover {
   background-color: #2DBDC2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003187}}
+@media -sass-debug-info{filename{}line{font-family:\00003192}}
 #avg_rating-marker {
   color: #2C9FA3;
   margin-right: 0px;
@@ -341,7 +345,7 @@ input {
 }
 
 /*************** RESOURCE VIEW SPECIFIC STYLES ****************/
-@media -sass-debug-info{filename{}line{font-family:\00003196}}
+@media -sass-debug-info{filename{}line{font-family:\00003201}}
 #resource-info {
   background-color: #F8F8F8;
   border: solid #CCCCCC;
@@ -350,42 +354,42 @@ input {
   overflow: scroll;
   padding: 1.25em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003205}}
+@media -sass-debug-info{filename{}line{font-family:\00003210}}
 #resource-info > .ui.header > .sub.header > .ui.label {
   margin-left: 0px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003209}}
+@media -sass-debug-info{filename{}line{font-family:\00003214}}
 #resource-info #resource-name {
   display: inline;
   font-size: 36px;
   padding-bottom: 1em;
   padding-top: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003216}}
+@media -sass-debug-info{filename{}line{font-family:\00003221}}
 #resource-info .successMessage {
   display: none;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003220}}
+@media -sass-debug-info{filename{}line{font-family:\00003225}}
 #resource-info .sub.header {
   font-size: 14px;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003224}}
+@media -sass-debug-info{filename{}line{font-family:\00003229}}
 #resource-info .ui.label {
   font-size: 14px;
   margin-top: 0.4em;
   margin-bottom: 1em;
 }
-@media -sass-debug-info{filename{}line{font-family:\00003230}}
+@media -sass-debug-info{filename{}line{font-family:\00003235}}
 #resource-info .ui.header {
   color: #2C9FA3;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003236}}
+@media -sass-debug-info{filename{}line{font-family:\00003241}}
 #descriptor-name {
   font-family: "Nunito Sans", sans-serif;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003240}}
+@media -sass-debug-info{filename{}line{font-family:\00003245}}
 #back-button {
   color: #2C9FA3;
   display: inline-block;
@@ -394,41 +398,41 @@ input {
   z-index: 2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003248}}
+@media -sass-debug-info{filename{}line{font-family:\00003253}}
 #back-button:hover {
   color: #2DBDC2;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003252}}
+@media -sass-debug-info{filename{}line{font-family:\00003257}}
 #single-resource-map {
   height: 400px;
   width: 100%;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003257}}
+@media -sass-debug-info{filename{}line{font-family:\00003262}}
 #user-rating, .successMessage {
   margin-bottom: 1em;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003261}}
+@media -sass-debug-info{filename{}line{font-family:\00003266}}
 #user-rating {
   background-color: #F8F8F8;
   box-shadow: none;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003266}}
+@media -sass-debug-info{filename{}line{font-family:\00003271}}
 #avg_rating {
   color: #2C9FA3;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003270}}
+@media -sass-debug-info{filename{}line{font-family:\00003275}}
 #submit-rating {
   background-color: #2C9FA3;
   color: #fff;
   font-weight: 400;
 }
 
-@media -sass-debug-info{filename{}line{font-family:\00003276}}
+@media -sass-debug-info{filename{}line{font-family:\00003281}}
 #submit-rating:hover {
   background-color: #2DBDC2;
 }
@@ -443,10 +447,10 @@ input {
   margin-bottom: 50px;
   left: 50%;
   position: absolute;
-  -webkit-transform: translate(-50%, 0%);
-  -ms-transform: translate(-50%, 0%);
-  transform: translate(-50%, 0%);
   top: 75px;
+  transform: translate(-50%, 0%);
+  -ms-transform: translate(-50%, 0%);
+  -webkit-transform: translate(-50%, 0%);
 }
 
 @media -sass-debug-info{filename{}line{font-family:\0000322}}

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -160,9 +160,9 @@
       </div>
     </h3>
     {% raw %}{{#if responsive}}{% endraw %}
-      <a class="ui button item" id="mobile-list-btn">
-        <i class="list icon"></i>
-        <p>Show List</p>
+      <a class="ui label" id="mobile-list-btn">
+        <i class="chevron left icon"></i>
+        <p>Back to List</p>
       </a>
     {% raw %}{{/if}}{% endraw %}
   </div>


### PR DESCRIPTION
Some style changes for the recent merge with maps4all

When clicking on an item in the resource view, change the header and chevron color. It's hard to change the background color of the item since it has a margin and padding on it that don't get colored

Selection uses the orange from the mockups:
![screen shot 2016-12-12 at 1 29 40 pm](https://cloud.githubusercontent.com/assets/5404536/21111349/1a430594-c06f-11e6-8289-00597c83913a.png)

Hover uses dark grey:
![screen shot 2016-12-12 at 1 29 49 pm](https://cloud.githubusercontent.com/assets/5404536/21111356/2535ce6e-c06f-11e6-9995-225988aec8a7.png)

TODO: Markers need icons to change color - look into making icon pngs later

Change style of mobile info window to include 'Back to List' link
![screen shot 2016-12-12 at 1 31 43 pm](https://cloud.githubusercontent.com/assets/5404536/21111406/6b2f59a8-c06f-11e6-9a0f-90ad804c6f01.png)
