### PR TITLE
removed function for focus outside of edit box

### DIFF
--- a/app/templates/macros/page_macros.html
+++ b/app/templates/macros/page_macros.html
@@ -3,7 +3,7 @@
         <div class="ui segment">
             <div id="editor-{{ editable_html_obj.editor_name }}" class="editor-admin" contenteditable="false">
             {{ editable_html_obj.value|safe }}
-            </div>
+        </div>
         </div>
        <button class="ui button start-edit">
         Edit
@@ -78,10 +78,6 @@
             cancelEdit();
         });
 
-        //We want the blue focus border to appear even when we click outside of the border in order to denote an edit state
-        $("#" + editorIDName).focusout(function() {
-            this.focus();
-        });
     });
     </script>
 

--- a/app/templates/macros/page_macros.html
+++ b/app/templates/macros/page_macros.html
@@ -3,7 +3,7 @@
         <div class="ui segment">
             <div id="editor-{{ editable_html_obj.editor_name }}" class="editor-admin" contenteditable="false">
             {{ editable_html_obj.value|safe }}
-        </div>
+            </div>
         </div>
        <button class="ui button start-edit">
         Edit


### PR DESCRIPTION
You could not type into the url box for the link popup or any popup from the ckeditor. By removing the function responsible for the focus outside of the edit box the bug is fixed