### PR TITLE
Add removing descriptor workflow in CSV

### DIFF
--- a/app/bulk_resource/views.py
+++ b/app/bulk_resource/views.py
@@ -110,7 +110,6 @@ def upload_row():
                 f.strip() and f.strip() != 'Name' and f.strip() != 'Address']
 
             # store descriptors to remove
-            # TODO: handle to remove descriptors in CSV workflow
             removed = set(old_d) - set(new_d)
             for f in removed:
                 old_desc = Descriptor.query.filter_by(
@@ -340,11 +339,16 @@ def set_descriptor_types():
     form.descriptor_types.label = ''
 
     # Show what type is for each existing descriptor (but don't allow to change)
+    # Also show which ones to remove
     existing_descs = []
+    remove_descs = []
     if csv_storage.action == 'update':
-        existing_descs = Descriptor.query.all()
+        remove_descs = [d.name for d in csv_storage.csv_descriptors_remove]
+        existing_descs = [d for d in Descriptor.query.all() if d.name not in remove_descs]
+
     return render_template('bulk_resource/set_descriptor_types.html',
-                           form=form, existing_descs=existing_descs, num=num)
+                           form=form, existing_descs=existing_descs,
+                           num=num, remove_descs=remove_descs)
 
 
 ''' If there are option descriptors in the CSV, display the option values parsed
@@ -457,13 +461,14 @@ def set_required_option_descriptor():
     # If there is an existing required option descriptor, then make it
     # the default choice
     req_name = ''
+    remove_descs = [d.name for d in csv_storage.csv_descriptors_remove]
     if csv_storage.action == 'update':
         req_opt_desc = RequiredOptionDescriptor.query.all()[0]
         if req_opt_desc.descriptor_id != -1:
             descriptor = Descriptor.query.filter_by(
                 id=req_opt_desc.descriptor_id
             ).first()
-            if descriptor is not None:
+            if descriptor is not None and descriptor.name not in remove_descs:
                 req_name = descriptor.name
                 descriptors.append(req_name)
 
@@ -628,6 +633,14 @@ def save_csv():
                     is_searchable=True,
                 )
                 db.session.add(descriptor)
+
+        # Remove descriptors not in the CSV
+        for desc in csv_storage.csv_descriptors_remove:
+            d = Descriptor.query.get(desc.descriptor_id)
+            if d is None:
+                db.session.rollback()
+                abort(404)
+            db.session.delete(d)
 
         # Create/update rows and descriptor associations
         for row in csv_storage.csv_rows:

--- a/app/models/csv.py
+++ b/app/models/csv.py
@@ -82,7 +82,6 @@ class CsvDescriptor(db.Model):
 
 class CsvDescriptorRemove(db.Model):
     """
-    (CURRENTLY NOT IN USE)
     Representation of a descriptor (header) not in the CSV but in the app
     - In updates, if a descriptor is in the app but not in the new CSV then we
     assume deletion of this descriptor

--- a/app/templates/bulk_resource/get_required_option_descriptor.html
+++ b/app/templates/bulk_resource/get_required_option_descriptor.html
@@ -42,7 +42,8 @@
               Required option descriptor denotes an option descriptor that every resource
               needs to have a value for and will be the primary filter in search.
               You can only choose from the option descriptors in the current CSV and the
-              current required option descriptor (if any).
+              current required option descriptor (if any). You cannot choose from
+              removed descriptors.
               {% if current %}
                 <p>The current required option descriptor is: <b>{{ current }}</b></p>
               {% endif %}

--- a/app/templates/bulk_resource/set_descriptor_types.html
+++ b/app/templates/bulk_resource/set_descriptor_types.html
@@ -72,6 +72,26 @@
                 {% endfor %}
               </div>
             {% endif %}
+
+            {% if remove_descs %}
+            <h4 class="ui header">
+              Descriptor Types To Be Removed
+              <div class="sub header">
+                These are the descriptors currently in the app but <b>NOT</b> in the CSV,
+                and will be deleted. If you did not want to delete these descriptors, please add them
+                back into the CSV.
+              </div>
+            </h4>
+            <div class="ui relaxed list">
+              {% for desc in remove_descs %}
+              <div class="item">
+                <div class="content">
+                  <h5 class="header">{{ desc }}</h5>
+                </div>
+              </div>
+              {% endfor %}
+            </div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/app/templates/bulk_resource/set_descriptor_types.html
+++ b/app/templates/bulk_resource/set_descriptor_types.html
@@ -36,18 +36,6 @@
         <div>
 
         <div class="twelve wide column">
-            <h4 class="ui header">
-              Set New Descriptor Types
-              <div class="sub header">
-                We have identified these new descriptors in your CSV file. Please
-                identify each descriptor as either a text or an option descriptor.
-              </div>
-            </h4>
-            {% if num == 0 %}
-              <i>No new descriptor types in CSV</i>
-            {% endif %}
-            {{ f.render_form(form) }}
-
             {% if existing_descs %}
               <h4 class="ui header">
                 Existing Descriptor Types
@@ -71,6 +59,7 @@
                 </div>
                 {% endfor %}
               </div>
+              <div class="ui divider"></div>
             {% endif %}
 
             {% if remove_descs %}
@@ -91,7 +80,20 @@
               </div>
               {% endfor %}
             </div>
+            <div class="ui divider"></div>
             {% endif %}
+
+            <h4 class="ui header">
+              Set New Descriptor Types
+              <div class="sub header">
+                We have identified these new descriptors in your CSV file. Please
+                identify each descriptor as either a text or an option descriptor.
+              </div>
+            </h4>
+            {% if num == 0 %}
+              <i>No new descriptor types in CSV</i>
+            {% endif %}
+            {{ f.render_form(form) }}
         </div>
     </div>
 {% endblock %}

--- a/app/templates/bulk_resource/upload.html
+++ b/app/templates/bulk_resource/upload.html
@@ -21,10 +21,14 @@
                     a resource in the app, they are assumed to be the same resource.
                     Then, the data of the resource in the app will be replaced with
                     the data in the CSV. So determining if two resources are the same or not is based on
-                    their name.
+                    their name. <b>Note: resources must have unique names then.</b>
                   </div>
                   <div class="ui item">
-                    Resources that are in the app but not in the CSV will not be
+                    Resources that are in the app but not in the CSV <b>will not</b> be
+                    removed.
+                  </div>
+                  <div class="ui item">
+                    Descriptors that are in the app but not in the CSV <b>will be</b>
                     removed.
                   </div>
                 </div>

--- a/manage.py
+++ b/manage.py
@@ -81,7 +81,7 @@ def setup_dev():
     """Runs the set-up needed for local development."""
     setup_general()
 
-    admin_email = Config.ADMIN_EMAIL
+    admin_email = os.environ.get('ADMIN_EMAIL')
     if User.query.filter_by(email=admin_email).first() is None:
         User.create_confirmed_admin('Default',
                                     'Admin',


### PR DESCRIPTION
- Finds descriptors in the app that are not in the CSV
- If it's the current required option descriptor, removes it from the list of possible option descriptors that can be the new required option descriptor
- Deletes the descriptor and its association on "Save" in the CSV workflow