### PR TITLE
Change mail port

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ class Config:
     SQLALCHEMY_COMMIT_ON_TEARDOWN = True
 
     MAIL_SERVER = 'smtp.sendgrid.net'
-    MAIL_PORT = 465
+    MAIL_PORT = 587
     MAIL_USE_TLS = True
     MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
     MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')


### PR DESCRIPTION
Change back mail port to 587 which will have fewer rate limiting and restrictions according to Sendgrid
https://sendgrid.com/docs/Classroom/Basics/Email_Infrastructure/recommended_smtp_settings.html