### PR TITLE
Fix descriptor associations querying and option value deleting

### DIFF
--- a/app/assets/styles/admin.scss
+++ b/app/assets/styles/admin.scss
@@ -63,3 +63,8 @@ $transform: translate(-50%,0%);
     margin-top: 0.5em;
   }
 }
+
+// tables
+td.descriptor.type {
+  display: table-cell;
+}

--- a/app/descriptor/views.py
+++ b/app/descriptor/views.py
@@ -255,14 +255,21 @@ def remove_option_value(desc_id, option_index):
 
     # If no resources are affected, just remove the option value.
     if len(option_assocs) == 0:
+        # HACK: keep descriptor value indices by inserting an empty string in place of the descriptor value
+        choice_names.insert(option_index, '')
         remove_value_from_db(descriptor, choice_names, old_value)
         return redirect(url_for('descriptor.descriptor_info', desc_id=desc_id))
 
     form = FixAllResourceOptionValueForm()
 
     if form.validate_on_submit():
-        for oa in option_assocs:
-            db.session.delete(oa)
+        OptionAssociation.query.filter(db.and_(
+            OptionAssociation.descriptor_id == desc_id,
+            OptionAssociation.option == option_index
+        )).delete()
+
+        # HACK: keep descriptor value indices by inserting an empty string in place of the descriptor value
+        choice_names.insert(option_index, '')
 
         if remove_value_from_db(descriptor, choice_names, old_value):
             return redirect(url_for('descriptor.descriptor_info',
@@ -308,6 +315,8 @@ def remove_option_value_req(desc_id, option_index):
 
     # If no resources are affected, just remove the option value.
     if len(option_assocs) == 0:
+        # HACK: keep descriptor value indices by inserting an empty string in place of the descriptor value
+        choice_names.insert(option_index, '')
         remove_value_from_db(descriptor, choice_names, old_value)
         return redirect(url_for('descriptor.descriptor_info', desc_id=desc_id))
 

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -61,7 +61,8 @@ def search_resources():
     if req_opt_desc and len(req_options) > 0:
         int_req_options = []
         for o in req_options:
-            int_req_options.append(req_opt_desc.values.index(str(o)))
+            if str(o) in req_opt_desc.values:
+                int_req_options.append(req_opt_desc.values.index(str(o)))
         for resource in resource_pool:
             associations = OptionAssociation.query.filter_by(
                 resource_id=resource.id,

--- a/app/models/resource.py
+++ b/app/models/resource.py
@@ -208,7 +208,9 @@ class Resource(db.Model):
                     resource_id=resource.id,
                     descriptor_id=req_opt_desc.id
                 ).all()
-                req = [a.descriptor.values[a.option] for a in associations]
+                for a in associations:
+                    if a.option < len(a.descriptor.values):
+                        req.append(a.descriptor.values[a.option])
             res['requiredOpts'] = req
 
             # set ratings

--- a/app/single_resource/views.py
+++ b/app/single_resource/views.py
@@ -1,7 +1,6 @@
 from flask import abort, flash, redirect, render_template, url_for, request
 from flask.ext.login import login_required
 from sqlalchemy.exc import IntegrityError
-from wtforms.fields import SelectMultipleField, TextAreaField
 from wtforms.fields import SelectMultipleField, SelectField, TextAreaField
 from flask_wtf.file import InputRequired
 

--- a/app/single_resource/views.py
+++ b/app/single_resource/views.py
@@ -72,7 +72,7 @@ def create():
     descriptors = Descriptor.query.all()
     for descriptor in descriptors:
         if descriptor.values:  # Fields for option descriptors.
-            choices = [(str(i), v) for i, v in enumerate(descriptor.values)]
+            choices = [(str(i), v) for i, v in enumerate(descriptor.values) if v]
             setattr(SingleResourceForm,
                     descriptor.name,
                     SelectMultipleField(choices=choices))
@@ -121,7 +121,7 @@ def edit(resource_id):
     descriptors = Descriptor.query.all()
     for descriptor in descriptors:
         if descriptor.values:  # Fields for option descriptors.
-            choices = [(str(i), v) for i, v in enumerate(descriptor.values)]
+            choices = [(str(i), v) for i, v in enumerate(descriptor.values) if v]
             default = None
             option_associations = OptionAssociation.query.filter_by(
                 resource_id=resource_id,

--- a/app/static/styles/app.css
+++ b/app/static/styles/app.css
@@ -56,6 +56,11 @@
   margin-top: 0.5em;
 }
 
+@media -sass-debug-info{filename{}line{font-family:\0000368}}
+td.descriptor.type {
+  display: table-cell;
+}
+
 @media -sass-debug-info{filename{}line{font-family:\0000316}}
 body {
   font-family: "Nunito Sans", sans-serif;

--- a/app/templates/descriptor/confirm_resources.html
+++ b/app/templates/descriptor/confirm_resources.html
@@ -22,7 +22,7 @@
                     Action Required
                     <div class="sub header">
                         Deleting the value <b> {{ desc.values[option_index] }} </b> from descriptor  {{ desc.name }}
-                        will affect these resources. Please select the new value for the resources below.
+                        will affect these resources. They will no longer have the <b> {{ desc.values[option_index] }} </b> value.
                     </div>
                 </div>
             </h3>
@@ -52,7 +52,7 @@
                         {% endfor %}
                         </tbody>
                     </table>
-                    
+
                     {{ f.form_message(flashes['error'], header='Something went wrong.', class='error') }}
                     {{ f.form_message(flashes['warning'], header='Check your email.', class='warning') }}
                     {{ f.form_message(flashes['info'], header='Information', class='info') }}

--- a/app/templates/descriptor/confirm_resources_req.html
+++ b/app/templates/descriptor/confirm_resources_req.html
@@ -1,0 +1,110 @@
+{% extends 'layouts/base.html' %}
+{% import 'macros/form_macros.html' as f %}
+
+{% block content %}
+    <div class="ui stackable grid container">
+        <div class="sixteen wide tablet twelve wide computer centered column">
+            <h2 class="ui header">
+                {{ desc.name }}
+                <div class="sub header">
+                    Resolve issues with current resources.
+                </div>
+            </h2>
+
+            <a class="ui basic compact button" href="{{ url_for('descriptor.change_option_values_index', desc_id=desc.id) }}">
+                <i class="caret left icon"></i>
+                Back to descriptor
+            </a>
+
+            <h3 class="ui red block header">
+                <i class="warning circle icon"></i>
+                <div class="content">
+                    Action Required
+                    <div class="sub header">
+                        Deleting the value <b> {{ desc.values[option_index] }} </b> from the <b> <u>required</u> descriptor {{ desc.name }} </b>
+                        will affect these resources. Please select the new value for the resources below.
+                    </div>
+                </div>
+            </h3>
+            {% set flashes = {
+                'error':   get_flashed_messages(category_filter=['form-error']),
+                'warning': get_flashed_messages(category_filter=['form-check-email']),
+                'info':    get_flashed_messages(category_filter=['form-info']),
+                'success': get_flashed_messages(category_filter=['form-success'])
+            } %}
+
+            {{ f.begin_form(form, flashes) }}
+
+                <h3 class="ui header">
+                  Resources that Must Change
+                  <div class="sub header">
+                    The value {{ desc.values[option_index] }} is the <b> only </b> required descriptor value
+                    for these resources. These resources need to have a new required option descriptor value set
+                    before deleting {{ desc.values[option_index] }}.
+                  </div>
+                </h3>
+
+                {% if missing_assocs|length > 0 %}
+                {# Use overflow-x: scroll so that mobile views don't freak out
+                 # when the table is too wide #}
+                <div style="overflow-x: scroll;">
+                    <table style="border=0" class="ui unstackable celled table">
+                        <thead>
+                            <tr>
+                                <th class="sorted ascending">Name</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {% for oa in missing_assocs %}
+                            <tr>
+                                <td><a href="{{ url_for('single_resource.edit', resource_id=oa.resource_id) }}">{{ oa.resource.name }}</a></td></td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                {% else %}
+                <p><i>No resources</i></p>
+                {% endif %}
+
+                <h3 class="ui header">
+                  Resources To Review
+                  <div class="sub header">
+                    The value {{ desc.values[option_index] }} is not the only required option descriptor value
+                    for these resources. It is fine deleting the value for these resources.
+                  </div>
+                </h3>
+                {% if option_assocs|length > 0 %}
+                {# Use overflow-x: scroll so that mobile views don't freak out
+                 # when the table is too wide #}
+                <div style="overflow-x: scroll;">
+                    <table style="border=0" class="ui unstackable celled table">
+                        <thead>
+                            <tr>
+                                <th class="sorted ascending">Name</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {% for oa in option_assocs %}
+                            <tr>
+                                <td><a href="{{ url_for('single_resource.edit', resource_id=oa.resource_id) }}">{{ oa.resource.name }}</a></td></td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                {% else %}
+                <p><i>No resources</i></p>
+                {% endif %}
+
+                {{ f.form_message(flashes['error'], header='Something went wrong.', class='error') }}
+                {{ f.form_message(flashes['warning'], header='Check your email.', class='warning') }}
+                {{ f.form_message(flashes['info'], header='Information', class='info') }}
+                {{ f.form_message(flashes['success'], header='Success!', class='success') }}
+
+                {{ f.render_form_field(form.submit) }}
+
+            {{ f.end_form() }}
+        </div>
+    </div>
+{% endblock %}

--- a/app/templates/descriptor/confirm_resources_req.html
+++ b/app/templates/descriptor/confirm_resources_req.html
@@ -22,7 +22,7 @@
                     Action Required
                     <div class="sub header">
                         Deleting the value <b> {{ desc.values[option_index] }} </b> from the <b> <u>required</u> descriptor {{ desc.name }} </b>
-                        will affect these resources. Please select the new value for the resources below.
+                        will affect these resources. They will no longer have the <b> {{ desc.values[option_index] }} </b> value.
                     </div>
                 </div>
             </h3>

--- a/app/templates/descriptor/index.html
+++ b/app/templates/descriptor/index.html
@@ -35,7 +35,13 @@
                                 <td></td>
                             {% else %}
                                 <td class="descriptor type">Option</td>
-                                <td>{{ ', '.join(d.values) }}</td>
+                                <td>
+                                  {% for v in d.values %}
+                                    {% if v %}
+                                      {{ v }}{% if not loop.last %},{% endif %}
+                                    {% endif %}
+                                  {% endfor %}
+                                </td>
                             {% endif %}
                         </tr>
                     {% endfor %}

--- a/app/templates/descriptor/manage_descriptor.html
+++ b/app/templates/descriptor/manage_descriptor.html
@@ -32,7 +32,16 @@
             <td>Text</td></tr>
         {% else %}
             <td>Option</td></tr>
-            <tr><td>Values</td><td>{{ ', '.join(desc.values) }}</td>
+            <tr>
+              <td>Values</td>
+              <td>
+                {% for v in desc.values %}
+                  {% if v %}
+                    {{ v }}{% if not loop.last %},{% endif %}
+                  {% endif %}
+                {% endfor %}
+              </td>
+            </tr>
         {% endif %}
     </table>
 {% endmacro %}
@@ -51,17 +60,19 @@
         <table class="ui basic collapsing table">
             <tbody>
             {% for i in range(desc.values|length) %}
+                {% if desc.values[i] %}
                 <tr>
                     <td>{{ desc.values[i] }}</td>
-                    <td><a class="ui edit button" 
+                    <td><a class="ui edit button"
                         href="{{ url_for('descriptor.edit_option_value', desc_id=desc.id, option_index=i) }}">
                         Edit
                     </a></td>
-                    <td><a class="ui negative deletion button" 
+                    <td><a class="ui negative deletion button"
                         href="{{ url_for('descriptor.remove_option_value', desc_id=desc.id, option_index=i) }}">
                         Remove
                     </a></td>
                 </tr>
+                {% endif %}
             {% endfor %}
                 <tr>
                     <td colspan="2">{{ f.render_form_field(form.value) }}</td>
@@ -144,5 +155,4 @@
             </div>
         </div>
     </div>
-
 {% endblock %}

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -23,10 +23,12 @@
           <div class="req-desc-name">{{ req_desc.name }}</div>
           <select id="search-resources-req-options" multiple="" class="ui fluid dropdown">
               {% for req_option in req_options.keys() %}
-              {% if req_options[req_option] %}
-                <option value="{{ req_option }}" selected="selected">{{ req_option }}</option>
-              {% else %}
-                <option value="{{ req_option }}" >{{ req_option }}</option>
+              {% if req_option %}
+                {% if req_options[req_option] %}
+                  <option value="{{ req_option }}" selected="selected">{{ req_option }}</option>
+                {% else %}
+                  <option value="{{ req_option }}" >{{ req_option }}</option>
+                {% endif %}
               {% endif %}
             {% endfor %}
           </select>
@@ -45,7 +47,9 @@
                   <div>{{ o }}</div>
                   <select multiple="" class="ui fluid dropdown search-resources-options" placeholder="Select">
                       {% for val in options[o] %}
+                        {% if val %}
                               <option value="{{ o }}:{{ val }}">{{ val }}</option>
+                        {% endif %}
                       {% endfor %}
                   </select>
               {% endfor %}


### PR DESCRIPTION
**1) Check if descriptor index exists before adding it to a list of values to display**
- Produced errors on prod

**2) Fix removing an option descriptor value**
- Before, an option descriptor value associations were not actually being deleted (calling individual delete on each result of a query filter `.all()` did not actually delete the associations, but now we just directly call `.delete()` on the returned query
- Deleting a value would change the index of the descriptor values list which made the existing descriptor option associations invalid since they were based off of the list index value. Now we just insert an empty string in place of the value and don't display the empty string in various views:
a) Main search dropdown view
b) Viewing descriptor values
c) List of possible descriptor values to delete
d) Creating and Editing a resource descriptor values dropdown

@riyer15 am i missing other possible views where you see all descriptor values?

**3) Enforce required option descriptor constraint**
- Before, if deleting an option value from a required descriptor value, we didn't enforce that a resource with only this option value for the required descriptor had to have a new option value to replace it. Now we don't allow deletion of the option value unless every resource in the app will have a value for the required descriptor after deleting the chosen option value.

![screen shot 2017-02-15 at 7 56 12 pm](https://cloud.githubusercontent.com/assets/5404536/23002466/da2636fc-f3b8-11e6-927d-cc4bcbfec780.png)
![screen shot 2017-02-15 at 7 56 18 pm](https://cloud.githubusercontent.com/assets/5404536/23002465/da25fe1c-f3b8-11e6-8c31-54d184ed203d.png)
