### PR TITLE
Changed login button text to admin

### DIFF
--- a/app/templates/account/login.html
+++ b/app/templates/account/login.html
@@ -5,7 +5,7 @@
   <div class="form-page">
     <div class="ui grid container" id="login">
         <div class="eight wide computer sixteen wide mobile centered column">
-            <h1 class="ui dividing header">Log in</h1>
+            <h1 class="ui dividing header">Admin Log in</h1>
 
             {% set flashes = {
                 'error':   get_flashed_messages(category_filter=['form-error']),

--- a/app/templates/account/login.html
+++ b/app/templates/account/login.html
@@ -5,7 +5,7 @@
   <div class="form-page">
     <div class="ui grid container" id="login">
         <div class="eight wide computer sixteen wide mobile centered column">
-            <h1 class="ui dividing header">Admin Log in</h1>
+            <h1 class="ui dividing header">Admin Login</h1>
 
             {% set flashes = {
                 'error':   get_flashed_messages(category_filter=['form-error']),

--- a/app/templates/macros/nav_macros.html
+++ b/app/templates/macros/nav_macros.html
@@ -113,7 +113,7 @@
         <a href="{{ url_for('account.logout') }}" class="item">Log out</a>
     {% else %}
         <a href="{{ url_for('suggestion.suggest') }}" class="item">Suggest Resource</a>
-        <a href="{{ url_for('account.login') }}" class="item">Log in</a>
+        <a href="{{ url_for('account.login') }}" class="item">Admin</a>
     {% endif %}
 
     {% if current_user.is_authenticated() %}


### PR DESCRIPTION
Navigation menu button renamed from "Login" to "Admin" to avoid confusing users

Login page title changed to "Admin Login" to reinforce that login is only for admin

<img width="1260" alt="screen shot 2017-04-26 at 2 22 40 pm" src="https://cloud.githubusercontent.com/assets/5404536/25450082/d66f18da-2a8b-11e7-9b17-7bf4b0ced822.png">
